### PR TITLE
Update version in pre-commit example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ There is a useful Python tool called [pre-commit](https://pre-commit.com/) that 
 
 ```
 -   repo: https://github.com/APIDevTools/swagger-cli
-    rev: v2.2.1
+    rev: v4.0.4
     hooks:
     - id: swagger-validation
       args: ["validate", "<path to root swagger>"]


### PR DESCRIPTION
The old version in the example was not working for me. 
```pre-commit install --install-hooks
pre-commit installed at .git/hooks/pre-commit
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Initializing environment for https://github.com/Lucas-C/pre-commit-hooks.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-yapf.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-pylint.
[INFO] Initializing environment for https://github.com/APIDevTools/swagger-cli.
An error has occurred: InvalidManifestError: 
=====> /<path-to-my-home-dir>/.cache/pre-commit/repobjoiqw90/.pre-commit-hooks.yaml does not exist
Check the log at / /<path-to-my-home-dir>/.cache/pre-commit/pre-commit.log
```


Updating to the latest, v4.0.4 version fixed this issue. 